### PR TITLE
Make nyc include all files in 'src' in report

### DIFF
--- a/functions/.nycrc.json
+++ b/functions/.nycrc.json
@@ -1,0 +1,10 @@
+{
+	"instrument": true,
+	"cache": false,
+	"all": true,
+	"include": [
+		"src"
+	],
+	"extension": [".ts"],
+	"parser-plugins": ["typescript"]
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,11 +16,6 @@
   "engines": {
     "node": "12"
   },
-  "nyc": {
-    "include": [
-      "src/**/*.ts"
-    ]
-  },
   "main": "lib/src/index.js",
   "dependencies": {
     "@google-cloud/logging-bunyan": "^3.0.1",


### PR DESCRIPTION
nyc config moved from 'package.json' to '.nycrc.json'. For some reason this seems to work better. nyc cache is also turned off.